### PR TITLE
Adding return code errors to DC script.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ convert_sv2v: synth elab_to_rtl
 synth:
 	mkdir -p $(OUTPUT_DIR)
 	$(eval -include $(DESIGN_DIRECTORIES_MK))
-	$(DC_SHELL) -64bit -f $(TOP_DIR)/scripts/tcl/run_dc.tcl 2>&1 | tee -i $(OUTPUT_DIR)/$(DESIGN_NAME).synth.log
+	set -o pipefail; $(DC_SHELL) -64bit -f $(TOP_DIR)/scripts/tcl/run_dc.tcl 2>&1 | tee -i $(OUTPUT_DIR)/$(DESIGN_NAME).synth.log
 
 elab_to_rtl:
 	mkdir -p $(OUTPUT_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 export TOP_DIR :=$(shell git rev-parse --show-toplevel)
 
+# Explicitly use bash so we can use the pipefail feature
+SHELL :=/bin/bash
+
 #===============================================================================
 # CAD TOOL SETUP
 #

--- a/scripts/tcl/run_dc.tcl
+++ b/scripts/tcl/run_dc.tcl
@@ -67,11 +67,15 @@ set_app_var search_path "$search_path [join $bsg_incdirs]"
 ### Perform analysis
 
 define_design_lib WORK -path $OUTPUT_DIR/${DESIGN_NAME}_WORK
-analyze -format sverilog -define $bsg_macros [join $bsg_filelist]
+if { ![analyze -format sverilog -define $bsg_macros [join $bsg_filelist]] } {
+  exit 1
+}
 
 ### Perform elaboration
 
-elaborate -param [join $bsg_params ","] $DESIGN_NAME
+if { ![elaborate -param [join $bsg_params ","] $DESIGN_NAME] } {
+  exit 2
+}
 
 ### Rename the design if it was modified from parameter
 
@@ -89,5 +93,5 @@ write_file -format verilog -hier -output $OUTPUT_FILE
 
 ### Finished!
 
-exit
+exit 0
 

--- a/scripts/tcl/run_dc.tcl
+++ b/scripts/tcl/run_dc.tcl
@@ -74,7 +74,7 @@ if { ![analyze -format sverilog -define $bsg_macros [join $bsg_filelist]] } {
 ### Perform elaboration
 
 if { ![elaborate -param [join $bsg_params ","] $DESIGN_NAME] } {
-  exit 2
+  exit 1
 }
 
 ### Rename the design if it was modified from parameter


### PR DESCRIPTION
I use pipefail to catch the return error code from DC while maintaining the pipe to tee for the log. This does make this makefile bash specific.