### PR TITLE
Update Makefile to clone iverilog using https:// protocol instead of git://

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ tools: $(IVERILOG_BUILD_DIR) $(PYPY3_BUILD_DIR) $(VIRTUALENV_BUILD_DIR) $(PYVERI
 
 $(IVERILOG_BUILD_DIR):
 	mkdir -p $(@D)
-	git clone git://github.com/steveicarus/iverilog.git $@
+	git clone https://github.com/steveicarus/iverilog.git $@
 	cd $@; git checkout v10_3
 	cd $@; sh autoconf.sh
 	cd $@; ./configure --prefix=$@/install


### PR DESCRIPTION
GitHub recently phased out support for the `git://` protocol, so you can't use it to clone anymore.
https://github.blog/2021-09-01-improving-git-protocol-security-github/